### PR TITLE
Use different Package References for .NET 6 and for .NET 7

### DIFF
--- a/WhatsappBusiness.CloudApi/WhatsappBusiness.CloudApi.csproj
+++ b/WhatsappBusiness.CloudApi/WhatsappBusiness.CloudApi.csproj
@@ -12,13 +12,22 @@
     <RepositoryUrl>https://github.com/gabrieldwight/Whatsapp-Business-Cloud-Api-Net</RepositoryUrl>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <Version>1.0.14</Version>
+    <Version>1.0.15</Version>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'netstandard2.1' or '$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.14" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' or '$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Currently this projects has Package References for the .NET 7 version of Microsoft.Extensions packages.

To avoid conflicts in projects using .NET 6 LTS, I have added separate package references for .NET 6.0 and .NET Standard 2.0 using the 6.x.x versions of Microsoft.Extensions packages.

The .NET 7 and .NET Standard 2.1 still use .NET 7 package references.