### PR TITLE
Fix a typo in MVC UI

### DIFF
--- a/Samples/WhatsAppBusinessCloudAPI.Web/Controllers/HomeController.cs
+++ b/Samples/WhatsAppBusinessCloudAPI.Web/Controllers/HomeController.cs
@@ -471,7 +471,7 @@ namespace WhatsAppBusinessCloudAPI.Web.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> SendWhatsAppTemplateMessage(SendTemplateMessageViewModel sendTemplateMessageViewModel)
+        public async Task<IActionResult> SendWhatsAppTextTemplateMessage(SendTemplateMessageViewModel sendTemplateMessageViewModel)
         {
             try
             {

--- a/Samples/WhatsAppBusinessCloudAPI.Web/Views/Home/SendWhatsAppTemplateMessage.cshtml
+++ b/Samples/WhatsAppBusinessCloudAPI.Web/Views/Home/SendWhatsAppTemplateMessage.cshtml
@@ -47,7 +47,7 @@
 					</div> <!--/. card-body -->
 					<div class="card-footer">
 						<div class="form-group">
-							<button asp-action="SendWhatsAppTextMessage" asp-controller="Home" class="btn btn-primary">Send Text Template Message (with Params or not)</button>
+							<button asp-action="SendWhatsAppTextTemplateMessage" asp-controller="Home" class="btn btn-primary">Send Text Template Message (with Params or not)</button>
 							<button asp-action="SendWhatsAppMediaTemplateMessageWithParameters" asp-controller="Home" class="btn btn-primary">Send Image Template Message With Parameters</button>
 							<button asp-action="SendWhatsAppVideoTemplateMessageWithParameters" asp-controller="Home" class="btn btn-primary">Send Video Template Message (with Params or not)</button>
 


### PR DESCRIPTION
- There was a typo in `SendWhatsAppTemplateMessage.cshtml` - it was calling `SendWhatsAppTextMessage` instead of `SendWhatsAppTemplateMessage`.
- Renamed the method `SendWhatsAppTemplateMessage` to `SendWhatsAppTextTemplateMessage` because all it does is create a new `TextTemplateMessageRequest`.