### PR TITLE
Manage templates - Add support for complex template creation

### DIFF
--- a/WhatsappBusiness.CloudApi.Tests/TestSetup.cs
+++ b/WhatsappBusiness.CloudApi.Tests/TestSetup.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace WhatsappBusiness.CloudApi.Tests;
+public class TestSetup
+{
+    public TestSetup()
+    {
+        var serviceCollection = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile(
+                 path: "appsettings.json",
+                 optional: false,
+                 reloadOnChange: true)
+           .Build();
+        serviceCollection.AddSingleton<IConfiguration>(configuration);
+
+        ServiceProvider = serviceCollection.BuildServiceProvider();
+    }
+
+    public ServiceProvider ServiceProvider { get; private set; }
+}

--- a/WhatsappBusiness.CloudApi.Tests/WhatsappBusiness.CloudApi.Tests.csproj
+++ b/WhatsappBusiness.CloudApi.Tests/WhatsappBusiness.CloudApi.Tests.csproj
@@ -1,0 +1,36 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="FluentAssertions" Version="8.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WhatsappBusiness.CloudApi\WhatsappBusiness.CloudApi.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/WhatsappBusiness.CloudApi.Tests/WhatsappBusinessClientTests.cs
+++ b/WhatsappBusiness.CloudApi.Tests/WhatsappBusinessClientTests.cs
@@ -1,0 +1,341 @@
+﻿using WhatsappBusiness.CloudApi.Messages.Requests;
+using WhatsappBusiness.CloudApi.Configurations;
+using WhatsappBusiness.CloudApi.Templates;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+
+namespace WhatsappBusiness.CloudApi.Tests
+{
+    public class WhatsappBusinessClientTests : IClassFixture<TestSetup>
+    {
+        private readonly WhatsAppBusinessCloudApiConfig _whatsAppConfig;
+        private readonly WhatsAppBusinessClient _client;
+
+        public WhatsappBusinessClientTests(TestSetup testSetup)
+        {
+            var configuration = testSetup.ServiceProvider.GetRequiredService<IConfiguration>();
+
+            _whatsAppConfig = new WhatsAppBusinessCloudApiConfig();
+            _whatsAppConfig.WhatsAppBusinessPhoneNumberId = configuration.GetSection("WhatsAppBusinessCloudApiConfiguration")["WhatsAppBusinessPhoneNumberId"];
+            _whatsAppConfig.WhatsAppBusinessAccountId = configuration.GetSection("WhatsAppBusinessCloudApiConfiguration")["WhatsAppBusinessAccountId"];
+            _whatsAppConfig.WhatsAppBusinessId = configuration.GetSection("WhatsAppBusinessCloudApiConfiguration")["WhatsAppBusinessId"];
+            _whatsAppConfig.AccessToken = configuration.GetSection("WhatsAppBusinessCloudApiConfiguration")["AccessToken"];
+            _whatsAppConfig.AppName = configuration.GetSection("WhatsAppBusinessCloudApiConfiguration")["AppName"];
+            _whatsAppConfig.Version = configuration.GetSection("WhatsAppBusinessCloudApiConfiguration")["Version"];
+            
+            var factory = new WhatsAppBusinessClientFactory();
+            _client = factory.Create(_whatsAppConfig);
+        }
+
+        [Fact(Skip = "Complete the WhatsAppBusinessCloudApiConfig to run the test.")]
+        public async Task CreateTemplateMessageAsync_UsingPositionalParameters_ShouldReturnCorrectStatus()
+        {
+            // Arrange
+            var firstNameExampleText = "John";
+            var companyNameExampleText = "My Company";
+            var templateCategory = "MARKETING"; // or "UTILITY" or "AUTHENTICATION"
+            var request = new BaseCreateTemplateMessageRequest
+            {
+                Name = $"test_template_{DateTime.UtcNow:yyyyMMddHHmmss}",
+                Category = templateCategory,
+                Language = "en_US",
+                Components = new List<object>
+                {
+                    new TemplateComponent
+                    {
+                        Type = "HEADER",
+                        Format = "TEXT",
+                        Text = "{{1}} Intro",
+                        Example = new TemplateComponentParameterExample
+                        {
+                            HeaderText = new List<string> { companyNameExampleText }
+                        }
+                    },
+                    new TemplateComponent
+                    {
+                        Type = "BODY",
+                        Text = "Hey {{1}}! {{2}} would love for you to schedule an appointment with us.",
+                        Example = new TemplateComponentParameterExample
+                        {
+                            BodyText = new List<List<string>>
+                            {
+                                new List<string>{ firstNameExampleText, companyNameExampleText }
+                            }
+                        }
+                    },
+                    new TemplateComponent
+                    {
+                        Type = "FOOTER",
+                        Text = "Reply STOP to unsubscribe."
+                    },
+                    new TemplateComponent
+                    {
+                        Type = "BUTTONS",
+                        Buttons = new List<TemplateComponentButton>
+                        {
+                            new TemplateComponentButton
+                            {
+                                Type = "QUICK_REPLY",
+                                Text = "YES"
+                            },
+                            new TemplateComponentButton
+                            {
+                                Type = "QUICK_REPLY",
+                                Text = "NO"
+                            }
+                        }
+                    }
+                }
+            };
+
+            // Act
+            var response = await _client.CreateTemplateMessageAsync(_whatsAppConfig.WhatsAppBusinessAccountId, request);
+
+            // Assert
+            response.Status.Should().NotBeNullOrEmpty();
+            response.Status.Should().BeOneOf("PENDING", "APPROVED");
+            response.Id.Should().NotBeNullOrEmpty();
+            response.Category.Should().Be(templateCategory);
+        }
+
+        [Fact(Skip = "WhatsApp Manager -> Manage Template -> Edit Template: Doesn't seem to like named parameters. It accepts only positional parameters.")]
+        //[Fact(Skip = "Complete the WhatsAppBusinessCloudApiConfig to run the test.")]
+        public async Task CreateTemplateMessageAsync_UsingNamedParameters_ShouldReturnCorrectStatus()
+        {
+            // Arrange
+            var firstNameParameterName = "first_name";
+            var firstNameExampleText = "John";
+            var companyNameParameterName = "company_name";
+            var companyNameExampleText = "My Company";
+            var templateCategory = "MARKETING"; // or "UTILITY" or "AUTHENTICATION"
+            var request = new BaseCreateTemplateMessageRequest
+            {
+                Name = $"test_template_{DateTime.UtcNow:yyyyMMddHHmmss}",
+                Category = templateCategory,
+                Language = "en_US",
+                Components = new List<object>
+                {
+                    new TemplateComponent
+                    {
+                        Type = "HEADER",
+                        Format = "TEXT",
+                        Text = $"{{{{{companyNameParameterName}}}}} Intro",
+                        Example = new TemplateComponentParameterExample
+                        {
+                            HeaderTextNamedParameters = new List<TemplateComponentNamedParameter>
+                            {
+                                new TemplateComponentNamedParameter
+                                {
+                                    Name = companyNameParameterName,
+                                    Example = companyNameExampleText
+                                }
+                            }
+                        }
+                    },
+                    new TemplateComponent
+                    {
+                        Type = "BODY",
+                        Text = $"Hey {{{{{firstNameParameterName}}}}}! {{{{{companyNameParameterName}}}}} would love for you to schedule an appointment with us.",
+                        Example = new TemplateComponentParameterExample
+                        {
+                            BodyTextNamedParameters = new List<TemplateComponentNamedParameter>
+                            {
+                                new TemplateComponentNamedParameter
+                                {
+                                    Name = firstNameParameterName,
+                                    Example = firstNameExampleText
+                                },
+                                new TemplateComponentNamedParameter
+                                {
+                                    Name = companyNameParameterName,
+                                    Example = companyNameExampleText
+                                }
+                            }
+                        }
+                    },
+                    new TemplateComponent
+                    {
+                        Type = "FOOTER",
+                        Text = "Reply STOP to unsubscribe."
+                    },
+                    new TemplateComponent
+                    {
+                        Type = "BUTTONS",
+                        Buttons = new List<TemplateComponentButton>
+                        {
+                            new TemplateComponentButton
+                            {
+                                Type = "QUICK_REPLY",
+                                Text = "YES"
+                            },
+                            new TemplateComponentButton
+                            {
+                                Type = "QUICK_REPLY",
+                                Text = "NO"
+                            }
+                        }
+                    }
+                }
+            };
+
+            // Act
+            var response = await _client.CreateTemplateMessageAsync(_whatsAppConfig.WhatsAppBusinessAccountId, request);
+
+            // Assert
+            response.Status.Should().NotBeNullOrEmpty();
+            response.Status.Should().BeOneOf("PENDING", "APPROVED");
+            response.Id.Should().NotBeNullOrEmpty();
+            response.Category.Should().Be(templateCategory);
+        }
+
+        [Fact(Skip = "Complete the WhatsAppBusinessCloudApiConfig to run the test.")]
+        public async Task GetAllTemplatesAsync_ShouldReturnSuccess()
+        {
+            // Act
+            var response = await _client.GetAllTemplatesAsync(_whatsAppConfig.WhatsAppBusinessAccountId);
+
+            // Assert
+            response.Should().NotBeNull();
+            response.Data.Should().NotBeNull();
+            response.Data.Should().AllSatisfy(x => x.Id.Should().NotBeNullOrEmpty());
+        }
+
+        [Fact(Skip = "Complete the WhatsAppBusinessCloudApiConfig to run the test.")]
+        public async Task GetTemplateByIdAsync_ShouldReturnSuccess()
+        {
+            // Arrange
+            var templateId = "your_template_id";
+            // Act
+            var response = await _client.GetTemplateByIdAsync(templateId);
+
+            // Assert
+            response.Should().NotBeNull();
+            response.Id.Should().NotBeNullOrEmpty();
+            response.Name.Should().NotBeNullOrEmpty();
+            response.Status.Should().NotBeNullOrEmpty();
+            response.Components.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact(Skip = "Complete the WhatsAppBusinessCloudApiConfig to run the test.")]
+        public async Task GetTemplateByNameAsync_ShouldReturnSuccess()
+        {
+            // Arrange
+            var templateName = "hello_world";
+            // Act
+            var response = await _client.GetTemplateByNameAsync(_whatsAppConfig.WhatsAppBusinessAccountId, templateName);
+
+            // Assert
+            response.Should().NotBeNull();
+            response.Data.Should().NotBeNullOrEmpty();
+            var templateData = response.Data.FirstOrDefault();
+            templateData.Should().NotBeNull();
+            templateData.Id.Should().NotBeNullOrEmpty();
+            templateData.Name.Should().NotBeNullOrEmpty();
+            templateData.Status.Should().NotBeNullOrEmpty();
+            templateData.Components.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact(Skip = "Complete the WhatsAppBusinessCloudApiConfig to run the test.")]
+        public async Task DeleteTemplateByIdAsync_ShouldReturnSuccess()
+        {
+            // Arrange
+            var templateId = "your_template_id";
+            var templateName = "your_template_name";
+            // Act
+            var response = await _client.DeleteTemplateByIdAsync(_whatsAppConfig.WhatsAppBusinessAccountId, templateId, templateName);
+
+            // Assert
+            response.Should().NotBeNull();
+            response.Success.Should().BeTrue();
+        }
+
+        [Fact(Skip = "Complete the WhatsAppBusinessCloudApiConfig to run the test.")]
+        public async Task SendTextMessageTemplateAsync_WithoutParameters_ShouldReturnSuccess()
+        {
+            // Arrange
+            var request = new TextTemplateMessageRequest
+            {
+                To = "your_registered_phone_number",
+                Template = new TextMessageTemplate
+                {
+                    Name = "hello_world",
+                    Language = new TextMessageLanguage
+                    {
+                        Code = "en_US"
+                    }
+                }
+            };
+            // Act
+            var response = await _client.SendTextMessageTemplateAsync(request);
+
+            // Assert
+            response.Should().NotBeNull();
+            response.Messages.Should().NotBeNullOrEmpty();
+            response.Contacts.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact(Skip = "Complete the WhatsAppBusinessCloudApiConfig to run the test.")]
+        public async Task SendTextMessageTemplateAsync_WithParameters_ShouldReturnSuccess()
+        {
+            // Arrange
+            var phoneNumber = "your_phone_number"; // Example phone number, should be a valid WhatsApp registered number
+            var templateName = "test_template_20250715112934"; // Example template name, should match an existing template
+            var firstName = "John";
+            var companyName = "My Company";
+
+            var request = new TextTemplateMessageRequest
+            {
+                To = phoneNumber,
+                Template = new TextMessageTemplate
+                {
+                    Name = templateName,
+                    Language = new TextMessageLanguage
+                    {
+                        Code = "en_US"
+                    },
+                    Components = new List<TextMessageComponent>
+                    {
+                        new TextMessageComponent
+                        {
+                            Type = "HEADER",
+                            Parameters = new List<TextMessageParameter>
+                            {
+                                new TextMessageParameter
+                                {
+                                    Type = "text",
+                                    Text = companyName
+                                }
+                            }
+                        },
+                        new TextMessageComponent
+                        {
+                            Type = "BODY",
+                            Parameters = new List<TextMessageParameter>
+                            {
+                                new TextMessageParameter
+                                {
+                                    Type = "text",
+                                    Text = firstName
+                                },
+                                new TextMessageParameter
+                                {
+                                    Type = "text",
+                                    Text = companyName
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            // Act
+            var response = await _client.SendTextMessageTemplateAsync(request);
+
+            // Assert
+            response.Should().NotBeNull();
+            response.Messages.Should().NotBeNullOrEmpty();
+            response.Contacts.Should().NotBeNullOrEmpty();
+        }
+    }
+}

--- a/WhatsappBusiness.CloudApi.Tests/appsettings.json
+++ b/WhatsappBusiness.CloudApi.Tests/appsettings.json
@@ -1,0 +1,16 @@
+{
+  "WhatsAppBusinessCloudApiConfiguration": {
+    "WhatsAppBusinessPhoneNumberId": "YOUR_PHONE_NUMBER_ID",
+    "WhatsAppBusinessAccountId": "YOUR_WABA_ID",
+    "WhatsAppBusinessId": "YOUR_BUSINESS_ID",
+    "AccessToken": "YOUR_ACCESS_TOKEN",
+    "Version": "v23.0"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/WhatsappBusiness.CloudApi/Templates/TemplateComponent.cs
+++ b/WhatsappBusiness.CloudApi/Templates/TemplateComponent.cs
@@ -1,9 +1,103 @@
-﻿namespace WhatsappBusiness.CloudApi.Templates
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace WhatsappBusiness.CloudApi.Templates
 {
-	public class TemplateComponent
-	{
-		public string Type { get; set; }  // "header", "body", "footer", "button"
-		public string Text { get; set; }  // Used for header (text) and footer
-		public object[] Parameters { get; set; }  // Used for body, buttons, and media headers
-	}
+    public class TemplateComponent
+    {
+        [JsonPropertyName("type")]
+        public string Type { get; set; }  // "HEADER", "BODY", "FOOTER", "BUTTONS"
+
+        [JsonPropertyName("text")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string Text { get; set; }  // Used for header, body and footer. Should be null when Type is BUTTONS
+
+        [JsonPropertyName("format")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string Format { get; set; }  // Used for header (TEXT)
+
+        /// <summary>
+        /// Use this property only when sending a template. Do not using when creating a template.
+        /// </summary>
+        [JsonPropertyName("parameters")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public object[] Parameters { get; set; }  // Used for body, buttons, and media headers
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonPropertyName("example")]
+        public TemplateComponentParameterExample Example { get; set; }
+
+        [JsonPropertyName("buttons")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<TemplateComponentButton> Buttons { get; set; }
+    }
+
+    public class TemplateComponentButton
+    {
+        /// <summary>
+        /// Supported types: "QUICK_REPLY", "URL", "PHONE_NUMBER". Not supported yet: "COPY_CODE", "FLOW".
+        /// </summary>
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        [JsonPropertyName("text")]
+        public string Text { get; set; }  // Button text
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonPropertyName("url")]
+        public string Url { get; set; }  // URL for URL button
+
+        /// <summary>
+        /// <para>Alphanumeric string. Business phone number to be called when the user taps the button.</para>
+        /// <para>Note that some countries have special phone numbers that have leading zeros after the country calling code (e.g., +55-0-955-585-95436). If you assign one of these numbers to the button, the leading zero will be stripped from the number. If your number will not work without the leading zero, assign an alternate number to the button, or add the number as message body text.</para>
+        /// <para>20 characters maximum.</para>
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonPropertyName("phone_number")]
+        public string PhoneNumber { get; set; }
+
+        /// <summary>
+        /// Required if Url contains a variable. The variable must be in the format {{1}}, {{2}}, etc.
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonPropertyName("example")]
+        public List<string> Example { get; set; }
+    }
+
+    public class TemplateComponentParameterExample
+    {
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonPropertyName("header_text")]
+        public List<string> HeaderText { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonPropertyName("header_text_named_params")]
+        public List<TemplateComponentNamedParameter> HeaderTextNamedParameters { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonPropertyName("body_text")]
+        public List<List<string>> BodyText { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonPropertyName("body_text_named_params")]
+        public List<TemplateComponentNamedParameter> BodyTextNamedParameters { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonPropertyName("footer_text")]
+        public List<string> FooterText { get; set; }
+    }
+
+    public class TemplateComponentNamedParameter
+    {
+        /// <summary>
+        /// Must be lowercase letters and underscores only.
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonPropertyName("param_name")]
+        public string Name { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonPropertyName("example")]
+        public string Example { get; set; }
+    }
 }

--- a/WhatsappBusiness.CloudApi/WhatsappBusiness.CloudApi.csproj
+++ b/WhatsappBusiness.CloudApi/WhatsappBusiness.CloudApi.csproj
@@ -12,7 +12,7 @@
     <RepositoryUrl>https://github.com/gabrieldwight/Whatsapp-Business-Cloud-Api-Net</RepositoryUrl>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <Version>1.0.70</Version>
+    <Version>1.0.71</Version>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0'">

--- a/WhatsappBusiness.sln
+++ b/WhatsappBusiness.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WhatsappBusiness.CloudApi",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WhatsAppBusinessCloudAPI.Web", "Samples\WhatsAppBusinessCloudAPI.Web\WhatsAppBusinessCloudAPI.Web.csproj", "{2EB4D948-49B6-443A-8831-09510073A356}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WhatsappBusiness.CloudApi.Tests", "WhatsappBusiness.CloudApi.Tests\WhatsappBusiness.CloudApi.Tests.csproj", "{C984A43C-0D95-4EB7-9CBD-458D0D3087F1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{2EB4D948-49B6-443A-8831-09510073A356}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2EB4D948-49B6-443A-8831-09510073A356}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2EB4D948-49B6-443A-8831-09510073A356}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C984A43C-0D95-4EB7-9CBD-458D0D3087F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C984A43C-0D95-4EB7-9CBD-458D0D3087F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C984A43C-0D95-4EB7-9CBD-458D0D3087F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C984A43C-0D95-4EB7-9CBD-458D0D3087F1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Modified `TemplateComponent` to be in line and up-to-date with the documentation:
https://developers.facebook.com/docs/whatsapp/business-management-api/message-templates#template-components
https://developers.facebook.com/docs/whatsapp/business-management-api/message-templates/components#body

Now it's enough to add positional parameters directly to `Text` property and set the `Example` usage hint.
```
new TemplateComponent
{
    Type = "BODY",
    Text = "Hey {{1}}! {{2}} would love for you to schedule an appointment with us.",
    Example = new TemplateComponentParameterExample
    {
        BodyText = new List<List<string>>
        {
            new List<string>{ "John", "My company" }
        }
    }
}

```

Note: `TemplateComponent.Parameters` property is only used when sending a template, it shouldn't be used when creating a new template.

Added xUnit test project `WhatsappBusiness.CloudApi.Tests` and `WhatsappBusinessClientTests`.

Tested `CreateTemplateMessageAsync`, `GetAllTemplatesAsync`, `GetTemplateByIdAsync`, `GetTemplateByNameAsync`, `DeleteTemplateByIdAsync`.

***Test Observations***
[2025-07-15]
Issue found on Meta's side during template creation. 
Template approval system doesn’t seem to like named parameters, even though the documentation states it is supported.
<img width="940" height="480" alt="image" src="https://github.com/user-attachments/assets/7aa8a5cb-d8e8-4f05-a830-5ac9b992ca24" />
Whereas, the positional parameters are accepted.
<img width="940" height="458" alt="image" src="https://github.com/user-attachments/assets/c8717c36-1090-443e-a129-5f5d8ddcdfe0" />

`GetAllTemplatesAsync`, `GetTemplateByIdAsync`, `GetTemplateByNameAsync` and `DeleteTemplateByIdAsync` were tested successfully.
 