### PR TITLE
Fix Webhook notifications. Add SignalR and Message Montor UI.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -365,3 +365,6 @@ FodyWeavers.xsd
 /Samples/WhatsAppBusinessCloudAPI.Web/appsettings.Development.json
 /Samples/WhatsAppBusinessCloudAPI.Web/wwwroot/Application_Files/MediaUploads
 /Samples/WhatsAppBusinessCloudAPI.Web/wwwroot/Application_Files/MediaDownloads
+
+# LibMan (Library Manager) - client-side libraries
+**/wwwroot/lib/

--- a/Samples/WhatsAppBusinessCloudAPI.Web/Controllers/HomeController.cs
+++ b/Samples/WhatsAppBusinessCloudAPI.Web/Controllers/HomeController.cs
@@ -37,6 +37,11 @@ namespace WhatsAppBusinessCloudAPI.Web.Controllers
             return View();
         }
 
+        public IActionResult Messages()
+        {
+            return View();
+        }
+
         public IActionResult SendWhatsAppTextMessage()
         {
             return View();

--- a/Samples/WhatsAppBusinessCloudAPI.Web/Controllers/WhatsAppNotificationController.cs
+++ b/Samples/WhatsAppBusinessCloudAPI.Web/Controllers/WhatsAppNotificationController.cs
@@ -19,7 +19,6 @@ namespace WhatsAppBusinessCloudAPI.Web.Controllers
         private readonly IWhatsAppBusinessClient _whatsAppBusinessClient;
         private readonly WhatsAppBusinessCloudApiConfig _whatsAppConfig;
         private readonly IWebHostEnvironment _webHostEnvironment;
-        private string VerifyToken = "<YOUR VERIFY TOKEN STRING>";
         private List<TextMessage> textMessage;
         private List<AudioMessage> audioMessage;
         private List<ImageMessage> imageMessage;
@@ -57,7 +56,7 @@ namespace WhatsAppBusinessCloudAPI.Web.Controllers
             _logger.LogInformation($"hub_challenge={hubChallenge}\n");
             _logger.LogInformation($"hub_verify_token={hubVerifyToken}\n");
 
-            if (!hubVerifyToken.Equals(VerifyToken))
+            if (!string.IsNullOrEmpty(_whatsAppConfig.WebhookVerifyToken) && !hubVerifyToken.Equals(_whatsAppConfig.WebhookVerifyToken))
             {
                 return Forbid("VerifyToken doesn't match");
             }

--- a/Samples/WhatsAppBusinessCloudAPI.Web/Hubs/WhatsAppMessagesHub.cs
+++ b/Samples/WhatsAppBusinessCloudAPI.Web/Hubs/WhatsAppMessagesHub.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.SignalR;
+
+namespace WhatsAppBusinessCloudAPI.Web.Hubs
+{
+    public class WhatsAppMessagesHub : Hub
+    {
+        public async Task JoinGroup(string groupName)
+        {
+            await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+        }
+
+        public async Task LeaveGroup(string groupName)
+        {
+            await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
+        }
+    }
+}

--- a/Samples/WhatsAppBusinessCloudAPI.Web/Models/WhatsAppMessageDisplay.cs
+++ b/Samples/WhatsAppBusinessCloudAPI.Web/Models/WhatsAppMessageDisplay.cs
@@ -1,0 +1,12 @@
+namespace WhatsAppBusinessCloudAPI.Web.Models
+{
+    public class WhatsAppMessageDisplay
+    {
+        public DateTime Timestamp { get; set; } = DateTime.Now;
+        public string MessageType { get; set; } = string.Empty;
+        public string From { get; set; } = string.Empty;
+        public string MessageContent { get; set; } = string.Empty;
+        public string RawJson { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
+    }
+}

--- a/Samples/WhatsAppBusinessCloudAPI.Web/Program.cs
+++ b/Samples/WhatsAppBusinessCloudAPI.Web/Program.cs
@@ -23,6 +23,7 @@ whatsAppConfig.WhatsAppBusinessId = builder.Configuration.GetSection("WhatsAppBu
 whatsAppConfig.AccessToken = builder.Configuration.GetSection("WhatsAppBusinessCloudApiConfiguration")["AccessToken"];
 whatsAppConfig.AppName = builder.Configuration.GetSection("WhatsAppBusinessCloudApiConfiguration")["AppName"];
 whatsAppConfig.Version = builder.Configuration.GetSection("WhatsAppBusinessCloudApiConfiguration")["Version"];
+whatsAppConfig.WebhookVerifyToken = builder.Configuration.GetSection("WhatsAppBusinessCloudApiConfiguration")["WebhookVerifyToken"];
 
 builder.Services.AddWhatsAppBusinessCloudApiService(whatsAppConfig);
 

--- a/Samples/WhatsAppBusinessCloudAPI.Web/Program.cs
+++ b/Samples/WhatsAppBusinessCloudAPI.Web/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json.Serialization;
 using WhatsappBusiness.CloudApi.Configurations;
 using WhatsappBusiness.CloudApi.Extensions;
+using WhatsAppBusinessCloudAPI.Web.Hubs;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -10,6 +11,9 @@ builder.Services.AddControllersWithViews().AddJsonOptions(options =>
 	options.JsonSerializerOptions.WriteIndented = true;
 	options.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
 });
+
+// Add SignalR for real-time message display
+builder.Services.AddSignalR();
 
 builder.Services.Configure<WhatsAppBusinessCloudApiConfig>(options =>
 {
@@ -37,7 +41,7 @@ if (!app.Environment.IsDevelopment())
     app.UseHsts();
 }
 
-app.UseHttpsRedirection();
+// app.UseHttpsRedirection();// Removed HTTPS redirection - let IIS handle it
 app.UseStaticFiles();
 
 app.UseRouting();
@@ -47,5 +51,8 @@ app.UseAuthorization();
 app.MapControllerRoute(
     name: "default",
     pattern: "{controller=Home}/{action=Index}/{id?}");
+
+// Map SignalR hub
+app.MapHub<WhatsAppMessagesHub>("/whatsappmessageshub");
 
 app.Run();

--- a/Samples/WhatsAppBusinessCloudAPI.Web/Views/Home/Messages.cshtml
+++ b/Samples/WhatsAppBusinessCloudAPI.Web/Views/Home/Messages.cshtml
@@ -1,0 +1,122 @@
+@{
+    ViewData["Title"] = "WhatsApp Messages Monitor";
+}
+
+<div class="row">
+    <div class="col-12">
+        <h2>@ViewData["Title"]</h2>
+        <p>Real-time WhatsApp messages received via webhook</p>
+        
+        <div class="mb-3">
+            <button id="connectBtn" class="btn btn-success" onclick="startConnection()">Connect</button>
+            <button id="disconnectBtn" class="btn btn-danger" onclick="stopConnection()" disabled>Disconnect</button>
+            <button id="clearBtn" class="btn btn-warning" onclick="clearMessages()">Clear Messages</button>
+        </div>
+        
+        <div id="connectionStatus" class="alert alert-secondary">
+            Status: Disconnected
+        </div>
+        
+        <div class="card">
+            <div class="card-header">
+                <h5>Incoming Messages <span id="messageCount" class="badge bg-primary">0</span></h5>
+            </div>
+            <div class="card-body">
+                <div id="messagesList" style="height: 600px; overflow-y: auto;">
+                    <!-- Messages will appear here -->
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script src="~/lib/signalr/dist/browser/signalr.min.js"></script>
+    <script>
+        "use strict";
+
+        var connection = null;
+        var messageCount = 0;
+
+        async function startConnection() {
+            connection = new signalR.HubConnectionBuilder()
+                .withUrl("/whatsappmessageshub")
+                .build();
+
+            connection.start().then(function () {
+                updateConnectionStatus("Connected", "alert-success");
+                document.getElementById("connectBtn").disabled = true;
+                document.getElementById("disconnectBtn").disabled = false;
+                
+                // Listen for messages
+                connection.on("ReceiveMessage", function (message) {
+                    addMessageToUI(message);
+                });
+                
+            }).catch(function (err) {
+                console.error(err.toString());
+                updateConnectionStatus("Connection Failed: " + err.toString(), "alert-danger");
+            });
+
+            connection.onclose(function () {
+                updateConnectionStatus("Disconnected", "alert-secondary");
+                document.getElementById("connectBtn").disabled = false;
+                document.getElementById("disconnectBtn").disabled = true;
+            });
+        }
+
+        function stopConnection() {
+            if (connection) {
+                connection.stop();
+            }
+        }
+
+        function updateConnectionStatus(status, alertClass) {
+            const statusDiv = document.getElementById("connectionStatus");
+            statusDiv.className = "alert " + alertClass;
+            statusDiv.textContent = "Status: " + status;
+        }
+
+        function addMessageToUI(message) {
+            messageCount++;
+            document.getElementById("messageCount").textContent = messageCount;
+            
+            const messagesList = document.getElementById("messagesList");
+            const messageDiv = document.createElement("div");
+            messageDiv.className = "mb-3 p-3 border rounded";
+            
+            const timestamp = new Date(message.timestamp).toLocaleString();
+            
+            messageDiv.innerHTML = `
+                <div class="row">
+                    <div class="col-md-6">
+                        <h6><span class="badge bg-info">${message.messageType}</span> from: ${message.from}</h6>
+                        <small class="text-muted">Received: ${timestamp} | Status: ${message.status}</small>
+                    </div>
+                    <div class="col-md-6">
+                        <h6>Raw JSON:</h6>
+                        <pre style="font-size: 10px; max-height: 200px; overflow: auto; background: #f8f9fa; padding: 10px;">${JSON.stringify(JSON.parse(message.rawJson), null, 2)}</pre>
+                    </div>
+                </div>
+            `;
+            
+            messagesList.insertBefore(messageDiv, messagesList.firstChild);
+            
+            // Keep only last 50 messages
+            while (messagesList.children.length > 50) {
+                messagesList.removeChild(messagesList.lastChild);
+            }
+        }
+
+        function clearMessages() {
+            document.getElementById("messagesList").innerHTML = "";
+            messageCount = 0;
+            document.getElementById("messageCount").textContent = messageCount;
+        }
+
+        // Auto-connect on page load
+        document.addEventListener("DOMContentLoaded", function() {
+            startConnection();
+        });
+    </script>
+}

--- a/Samples/WhatsAppBusinessCloudAPI.Web/Views/Shared/AdminLTE/_MainNavigation.cshtml
+++ b/Samples/WhatsAppBusinessCloudAPI.Web/Views/Shared/AdminLTE/_MainNavigation.cshtml
@@ -8,6 +8,15 @@
 		<nav class="mt-2">
 			<ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
 				<li class="nav-item ">
+					<a asp-controller="Home" asp-action="Messages" class="nav-link @Html.IsActive(nameof(HomeController).Replace("Controller", ""), nameof(HomeController.Messages))">
+						<i class="nav-icon fa-solid fa-comments"></i>
+						<p>
+							Messages Monitor
+						</p>
+					</a>
+				</li>
+				
+				<li class="nav-item ">
 					<a asp-controller="Home" asp-action="BulkSendWhatsApps" class="nav-link @Html.IsActive(nameof(HomeController).Replace("Controller", ""), nameof(HomeController.BulkSendWhatsApps))">
 						<i class="nav-icon fa-solid fa-upload"></i>
 						<p>

--- a/Samples/WhatsAppBusinessCloudAPI.Web/Views/Shared/_Layout.cshtml
+++ b/Samples/WhatsAppBusinessCloudAPI.Web/Views/Shared/_Layout.cshtml
@@ -23,6 +23,9 @@
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Messages">Messages Monitor</a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="SendWhatsAppTextMessage">Text Message</a>
                         </li>
                         <li class="nav-item">

--- a/Samples/WhatsAppBusinessCloudAPI.Web/libman.json
+++ b/Samples/WhatsAppBusinessCloudAPI.Web/libman.json
@@ -37,6 +37,15 @@
       "files": [
         "select2-bootstrap.min.css"
       ]
+    },
+    {
+      "provider": "unpkg",
+      "library": "@microsoft/signalr@8.0.0",
+      "destination": "wwwroot/lib/signalr/",
+      "files": [
+        "dist/browser/signalr.min.js",
+        "dist/browser/signalr.js"
+      ]
     }
   ]
 }

--- a/Samples/WhatsAppBusinessCloudAPI.Web/web.config
+++ b/Samples/WhatsAppBusinessCloudAPI.Web/web.config
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <location path="." inheritInChildApplications="false">
+    <system.webServer>
+      <handlers>
+        <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
+      </handlers>
+      <aspNetCore processPath="dotnet" arguments=".\WhatsAppBusinessCloudAPI.Web.dll" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" hostingModel="inprocess">
+        <environmentVariables>
+          <environmentVariable name="ASPNETCORE_HTTPS_PORT" value="443" />
+          <environmentVariable name="ASPNETCORE_FORWARDEDHEADERS_ENABLED" value="true" />
+        </environmentVariables>
+      </aspNetCore>
+    </system.webServer>
+  </location>
+</configuration>
+<!--ProjectGuid: 2EB4D948-49B6-443A-8831-09510073A356-->

--- a/WhatsappBusiness.CloudApi.Tests/WhatsappBusinessClientTests.cs
+++ b/WhatsappBusiness.CloudApi.Tests/WhatsappBusinessClientTests.cs
@@ -23,6 +23,7 @@ namespace WhatsappBusiness.CloudApi.Tests
             _whatsAppConfig.AccessToken = configuration.GetSection("WhatsAppBusinessCloudApiConfiguration")["AccessToken"];
             _whatsAppConfig.AppName = configuration.GetSection("WhatsAppBusinessCloudApiConfiguration")["AppName"];
             _whatsAppConfig.Version = configuration.GetSection("WhatsAppBusinessCloudApiConfiguration")["Version"];
+            _whatsAppConfig.WebhookVerifyToken = configuration.GetSection("WhatsAppBusinessCloudApiConfiguration")["WebhookVerifyToken"];
             
             var factory = new WhatsAppBusinessClientFactory();
             _client = factory.Create(_whatsAppConfig);

--- a/WhatsappBusiness.CloudApi.Tests/appsettings.json
+++ b/WhatsappBusiness.CloudApi.Tests/appsettings.json
@@ -4,7 +4,8 @@
     "WhatsAppBusinessAccountId": "YOUR_WABA_ID",
     "WhatsAppBusinessId": "YOUR_BUSINESS_ID",
     "AccessToken": "YOUR_ACCESS_TOKEN",
-    "Version": "v23.0"
+    "Version": "v23.0",
+    "WebhookVerifyToken": ""
   },
   "Logging": {
     "LogLevel": {

--- a/WhatsappBusiness.CloudApi/Configurations/WhatsAppBusinessCloudApiConfig.cs
+++ b/WhatsappBusiness.CloudApi/Configurations/WhatsAppBusinessCloudApiConfig.cs
@@ -8,5 +8,6 @@
         public string AccessToken { get; set; }
         public string AppName { get; set; }
         public string Version { get; set; }
+        public string WebhookVerifyToken { get; set; }
     }
 }

--- a/WhatsappBusiness.CloudApi/Extensions/ServiceCollectionExtension.cs
+++ b/WhatsappBusiness.CloudApi/Extensions/ServiceCollectionExtension.cs
@@ -38,7 +38,8 @@ namespace WhatsappBusiness.CloudApi.Extensions
                 WhatsAppBusinessId = whatsAppConfig.WhatsAppBusinessId,
                 AccessToken = whatsAppConfig.AccessToken,
                 AppName = whatsAppConfig.AppName,
-                Version = whatsAppConfig.Version
+                Version = whatsAppConfig.Version,
+                WebhookVerifyToken = whatsAppConfig.WebhookVerifyToken
             });
 
             services.AddHttpClient<IWhatsAppBusinessClient, WhatsAppBusinessClient>(options =>
@@ -79,7 +80,8 @@ namespace WhatsappBusiness.CloudApi.Extensions
                 WhatsAppBusinessId = whatsAppConfig.WhatsAppBusinessId,
                 AccessToken = whatsAppConfig.AccessToken,
                 AppName = whatsAppConfig.AppName,
-                Version = whatsAppConfig.Version
+                Version = whatsAppConfig.Version,
+                WebhookVerifyToken = whatsAppConfig.WebhookVerifyToken
             });
 
             services.AddHttpClient<IWhatsAppBusinessClient, WhatsAppBusinessClient>(options =>


### PR DESCRIPTION
Moved Webhook VerifyToken to WhatsAppBusinessCloudApiConfig.

In the latest document from Meta, 
https://developers.facebook.com/docs/whatsapp/cloud-api/guides/set-up-whatsapp-echo-bot

Meta makes a call directly to webhook URL without any extra path.
Removed Paths from HttpGet and HttpPost action in WhatsAppNotificationsController.

Added SignalR dependency.
Added Message Monitor UI to see incoming messages via webhook.
