### PR TITLE
Tests on shared WABAs

### DIFF
--- a/WhatsappBusiness.CloudApi.Tests/appsettings.json
+++ b/WhatsappBusiness.CloudApi.Tests/appsettings.json
@@ -7,6 +7,16 @@
     "Version": "v23.0",
     "WebhookVerifyToken": ""
   },
+  "SharedWhatsAppBusinessCloudApiConfigurations": [
+    {
+      "WhatsAppBusinessPhoneNumberId": "SHARED_PHONE_NUMBER_ID",
+      "WhatsAppBusinessAccountId": "SHARED_WABA_ID",
+      "WhatsAppBusinessId": "",
+      "AccessToken": "BUSINESS_INTEGRATION_SYSTEM_USER_ACCESS_TOKEN",
+      "Version": "v23.0",
+      "WebhookVerifyToken": ""
+    }
+  ],
   "EmbeddedSignupConfiguration": {
     "AppId": "YOUR_APP_ID",
     "AppSecret": "YOUR_APP_SECRET",


### PR DESCRIPTION
This PR just contains some changes in the tests.

The tests demonstrate how to:
- Load shared WABAs' configurations and api clients
- Create a message template in a shared WABA
- Send message template from a shared WABA