### PR TITLE
Added suppport for .NET Framework 4.7.2

### DIFF
--- a/WhatsappBusiness.CloudApi/Extensions/ServiceCollectionExtension.cs
+++ b/WhatsappBusiness.CloudApi/Extensions/ServiceCollectionExtension.cs
@@ -17,7 +17,7 @@ namespace WhatsappBusiness.CloudApi.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="whatsAppBusinessPhoneNumberId"></param>
-        public static void AddWhatsAppBusinessCloudApiService(this IServiceCollection services, WhatsAppBusinessCloudApiConfig whatsAppConfig, string graphAPIVersion = null)
+        public static void AddWhatsAppBusinessCloudApiService(this IServiceCollection services, WhatsAppBusinessCloudApiConfig whatsAppConfig, string? graphAPIVersion = null)
         {
             Random jitterer = new Random();
 
@@ -56,10 +56,14 @@ namespace WhatsappBusiness.CloudApi.Extensions
                 }
 
                 return handler;
+#if !NET472
             }).AddPolicyHandler(request => request.Method.Equals(HttpMethod.Get) ? retryPolicy : noOpPolicy);
+#else
+            });
+#endif
         }
 
-        public static void AddWhatsAppBusinessCloudApiService<THandler>(this IServiceCollection services, WhatsAppBusinessCloudApiConfig whatsAppConfig, string graphAPIVersion = null) where THandler : HttpMessageHandler
+        public static void AddWhatsAppBusinessCloudApiService<THandler>(this IServiceCollection services, WhatsAppBusinessCloudApiConfig whatsAppConfig, string? graphAPIVersion = null) where THandler : HttpMessageHandler
         {
             Random jitterer = new Random();
 
@@ -90,7 +94,11 @@ namespace WhatsappBusiness.CloudApi.Extensions
                 options.Timeout = TimeSpan.FromMinutes(10);
             }).SetHandlerLifetime(Timeout.InfiniteTimeSpan)
               .ConfigurePrimaryHttpMessageHandler<THandler>()
+#if !NET472
               .AddPolicyHandler(request => request.Method.Equals(HttpMethod.Get) ? retryPolicy : noOpPolicy);
+#else
+              ;
+#endif
         }
     }
 }

--- a/WhatsappBusiness.CloudApi/WhatsAppBusinessClient.cs
+++ b/WhatsappBusiness.CloudApi/WhatsAppBusinessClient.cs
@@ -44,7 +44,7 @@ namespace WhatsappBusiness.CloudApi
         /// Initialize WhatsAppBusinessClient with httpclient factory
         /// </summary>
         /// <param name="whatsAppConfig">WhatsAppBusiness configuration</param>
-        public WhatsAppBusinessClient(WhatsAppBusinessCloudApiConfig whatsAppConfig, string graphAPIVersion = null)
+        public WhatsAppBusinessClient(WhatsAppBusinessCloudApiConfig whatsAppConfig, string? graphAPIVersion = null)
         {
             var retryPolicy = HttpPolicyExtensions.HandleTransientHttpError()
                 .WaitAndRetryAsync(1, retryAttempt =>
@@ -69,7 +69,11 @@ namespace WhatsappBusiness.CloudApi
                 }
 
                 return handler;
+#if !NET472
             }).AddPolicyHandler(request => request.Method.Equals(HttpMethod.Get) ? retryPolicy : noOpPolicy);
+#else
+            });
+#endif
 
             var serviceProvider = services.BuildServiceProvider();
 
@@ -4324,9 +4328,7 @@ namespace WhatsappBusiness.CloudApi
 
 #if NET5_0_OR_GREATER
             var bytesDownloaded = await _httpClient.GetByteArrayAsync(whatsAppBusinessEndpoint, cancellationToken).ConfigureAwait(false);
-#endif
-
-#if NETSTANDARD2_0_OR_GREATER
+#elif NETSTANDARD2_0_OR_GREATER || NET472
             var bytesDownloaded = await _httpClient.GetByteArrayAsync(whatsAppBusinessEndpoint).ConfigureAwait(false);
 #endif
 

--- a/WhatsappBusiness.CloudApi/WhatsappBusiness.CloudApi.csproj
+++ b/WhatsappBusiness.CloudApi/WhatsappBusiness.CloudApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0;net472;netstandard2.1;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Gabriel Odero</Authors>
     <Description>This is C# wrapper of whatsapp business cloud api for .NET</Description>
@@ -32,10 +32,21 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.36" />
     <PackageReference Include="System.Text.Json" Version="6.0.11" />
+    <PackageReference Include="Polly" Version="7.2.2" />
+    <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="System.Text.Json" Version="9.0.7" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.11" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="Polly" Version="7.2.2" />
+    <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Added net472 as a target framework alongside the existing ones.
- Configured different versions of Microsoft.Extensions packages for compatibility:
- .NET Framework 4.7.2: Microsoft.Extensions.DependencyInjection 2.1.1, Microsoft.Extensions.Http 2.1.0.
- Other frameworks: Used their respective higher versions.
- Conditional Compilation - Added #if !NET472 directives to exclude AddPolicyHandler calls that aren't supported in older versions.
- Polly Integration - Added proper Polly packages for all target frameworks to enable retry policies where supported.